### PR TITLE
Feat/reset streak to zero

### DIFF
--- a/client/src/components/Timer.jsx
+++ b/client/src/components/Timer.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './Timer.css';
 
 function Timer({updateStreakScore, updateStarScore}) {
-    const totalSeconds = 120;
+    const totalSeconds = 3;
     const [isRunning, setIsRunning] = useState(false);
     const [remainingSeconds, setRemainingSeconds] = useState(totalSeconds);
     

--- a/client/src/components/Timer.jsx
+++ b/client/src/components/Timer.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import './Timer.css';
 
 function Timer({updateStreakScore, updateStarScore}) {
-    const totalSeconds = 3;
+    const totalSeconds = 120;
     const [isRunning, setIsRunning] = useState(false);
     const [remainingSeconds, setRemainingSeconds] = useState(totalSeconds);
     

--- a/server/src/endpoints/endpoints.js
+++ b/server/src/endpoints/endpoints.js
@@ -14,11 +14,26 @@ const setupServer = () => {
 
   app.get("/scores/:id", async (req, res) => {
     const userId = req.params.id;
+    const currentDate = new Date();
+
+    let lastBrush = await knex("brush_timestamps")
+      .max("brush_timestamp")
+      .where({"user_id": userId});
+    
+    let timeDifferenceInHours = Math.abs(currentDate.getTime() - lastBrush.getTime())/ (1000 * 3600);
+
+    if (timeDifferenceInHours >= 24) {
+      await knex("scores")
+      .where("user_id", userId)
+      .update({"streak_score": 0});
+    }
+
     let score = await knex("scores")
       .join("user_credentials", "user_credentials.id", "=", "scores.user_id")
       .select({streakScore: "streak_score", starScore: "star_score"})
       .where({"user_credentials.id": userId})
       .first();
+
     res.status(200).send(score);
   })
   

--- a/server/src/endpoints/endpoints.js
+++ b/server/src/endpoints/endpoints.js
@@ -42,15 +42,17 @@ const setupServer = () => {
     let lastBrush = await knex("brush_timestamps")
       .max("brush_timestamp")
       .where({"user_id": userId});
+    console.log("last brush:", lastBrush);
     
-    let timeDifferenceInHours = Math.abs(currentDate.getTime() - lastBrush.getTime())/ (1000 * 3600);
+    if (lastBrush[0].max !== null) {
+    let timeDifferenceInHours = Math.abs(currentDate.getTime() - lastBrush[0].max.getTime())/ (1000 * 3600);
 
     if (timeDifferenceInHours >= 24) {
       await knex("scores")
       .where("user_id", userId)
       .update({"streak_score": 0});
     }
-
+  }
     let score = await knex("scores")
       .join("user_credentials", "user_credentials.id", "=", "scores.user_id")
       .select({streakScore: "streak_score", starScore: "star_score"})


### PR DESCRIPTION
Streak is reset to 0 when last brushstamp of user is over 24 hours ago.  New user account will bypass streak check and display scores.